### PR TITLE
Changed the package name from `main` to `saml`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,55 @@ For instance, New Relic allows you to configure a saml provider (https://newreli
 
 Ping Identity has a nice video for SAML here: https://www.pingidentity.com/resource-center/Introduction-to-SAML-Video.cfm
 
+Installation
+------------
+
+Use the `go get` command to fetch `gosaml` and its dependencies into your local `$GOPATH`:
+
+    $ go get github.com/mattbaird/gosaml
+
+Usage
+-----
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/mattbaird/gosaml"
+)
+
+func main() {
+    // Configure the app and account settings
+    appSettings := saml.NewAppSettings("http://www.onelogin.net", "issuer")
+    accountSettings := saml.NewAccountSettings("cert", "http://www.onelogin.net")
+
+    // Construct an AuthnRequest
+    authRequest := saml.NewAuthorizationRequest(*appSettings, *accountSettings)
+
+    // Return a SAML AuthnRequest as a string
+    saml, err := authRequest.GetRequest(false)
+
+    if err != nil {
+        fmt.Println(err)
+        return
+    }
+    fmt.Println(saml)
+}
+```
+
+The above code will generate the following AuthnRequest XML:
+
+```xml
+<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    ID="_fd22bc94-0dee-489f-47d5-b86e3100268c" Version="2.0" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+    AssertionConsumerServiceURL="http://www.onelogin.net" IssueInstant="2014-09-02T13:15:28" AssertionConsumerServiceIndex="0"
+    AttributeConsumingServiceIndex="0">
+    <saml:Issuer>https://sp.example.com/SAML2</saml:Issuer>
+    <samlp:NameIDPolicy AllowCreate="true" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient"></samlp:NameIDPolicy>
+    <samlp:RequestedAuthnContext xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" Comparison="exact"></samlp:RequestedAuthnContext>
+    <saml:AuthnContextClassRef xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+        urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+    </saml:AuthnContextClassRef>
+</samlp:AuthnRequest>
+```

--- a/authrequest.go
+++ b/authrequest.go
@@ -1,4 +1,4 @@
-// Copyright 2012 Matthew Baird
+// Copyright 2014 Matthew Baird
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package saml
 
 import (
 	"encoding/base64"
@@ -99,33 +99,6 @@ func (ar AuthorizationRequest) GetRequestUrl() (string, error) {
 	}
 	u.Query().Add("SAMLRequest", base64EncodedUTF8SamlRequest)
 	return u.String(), nil
-}
-
-/*
- <samlp:AuthnRequest
-    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
-    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
-    ID="aaf23196-1773-2113-474a-fe114412ab72"
-    Version="2.0"
-    IssueInstant="2004-12-05T09:21:59"
-    AssertionConsumerServiceIndex="0"
-    AttributeConsumingServiceIndex="0">
-    <saml:Issuer>https://sp.example.com/SAML2</saml:Issuer>
-    <samlp:NameIDPolicy
-      AllowCreate="true"
-      Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient"/>
-  </samlp:AuthnRequest>
-*/
-func main() {
-	appSettings := NewAppSettings("http://www.onelogin.net", "issuer")
-	accountSettings := NewAccountSettings("cert", "http://www.onelogin.net")
-	authRequest := NewAuthorizationRequest(*appSettings, *accountSettings)
-	saml, err := authRequest.GetRequest(false)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-	fmt.Println(saml)
 }
 
 type AuthorizationRequest struct {

--- a/certificate.go
+++ b/certificate.go
@@ -1,4 +1,4 @@
-// Copyright 2012 Matthew Baird
+// Copyright 2014 Matthew Baird
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package saml
 
 import (
 	"crypto/x509"

--- a/response.go
+++ b/response.go
@@ -1,4 +1,4 @@
-// Copyright 2012 Matthew Baird
+// Copyright 2014 Matthew Baird
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package saml
 
 import (
 	"crypto/x509"


### PR DESCRIPTION
This will allow for `gosaml` to be used as a library as well as correctly fetched and imported with `go get`.

Additionally:
- Removed the `main` function from authrequest.go (done in conjunction with the package name change).
- Added additional "Installation" and "Usage" sections to the README.md to help get started.
- Updated the copyright date.

@mattbaird: I'm not sure about your use case for this library, so if this change is stepping on toes, I can keep it in my own fork.  My goal of this was to allow for improved organization while going forward and adding new features (ie, AuthnRequest signing is still in the works).
