### PR TITLE
bug fixes for Shibboleth interoperability

### DIFF
--- a/authnrequest.go
+++ b/authnrequest.go
@@ -34,7 +34,7 @@ func NewAuthorizationRequest(appSettings AppSettings, accountSettings AccountSet
 	}
 	//yyyy-MM-dd'T'H:mm:ss
 	layout := "2006-01-02T15:04:05"
-	t := time.Now().Format(layout)
+	t := time.Now().UTC().Format(layout)
 
 	return &AuthorizationRequest{AccountSettings: accountSettings, AppSettings: appSettings, Id: "_" + myIdUUID.String(), IssueInstant: t}
 }

--- a/authnrequest.go
+++ b/authnrequest.go
@@ -72,13 +72,14 @@ func (ar AuthorizationRequest) GetRequest(base64Encode bool) (string, error) {
 			},
 			SAMLP:      "urn:oasis:names:tc:SAML:2.0:protocol",
 			Comparison: "exact",
-		},
-		AuthnContextClassRef: AuthnContextClassRef{
-			XMLName: xml.Name{
-				Local: "saml:AuthnContextClassRef",
+
+			AuthnContextClassRef: AuthnContextClassRef{
+				XMLName: xml.Name{
+					Local: "saml:AuthnContextClassRef",
+				},
+				SAML:      "urn:oasis:names:tc:SAML:2.0:assertion",
+				Transport: "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport",
 			},
-			SAML:      "urn:oasis:names:tc:SAML:2.0:assertion",
-			Transport: "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport",
 		},
 	}
 	b, err := xml.MarshalIndent(d, "", "    ")

--- a/authnrequest.go
+++ b/authnrequest.go
@@ -56,7 +56,7 @@ func (ar AuthorizationRequest) GetRequest(base64Encode bool) (string, error) {
 			XMLName: xml.Name{
 				Local: "saml:Issuer",
 			},
-			Url: "https://sp.example.com/SAML2",
+			Url: ar.AppSettings.Issuer,
 		},
 		IssueInstant: ar.IssueInstant,
 		NameIDPolicy: NameIDPolicy{
@@ -120,7 +120,7 @@ func (ar AuthorizationRequest) GetSignedRequest(base64Encode bool, publicCert st
 			XMLName: xml.Name{
 				Local: "saml:Issuer",
 			},
-			Url: "https://sp.example.com/SAML2",
+			Url: ar.AppSettings.Issuer,
 		},
 		IssueInstant: ar.IssueInstant,
 		NameIDPolicy: NameIDPolicy{

--- a/authnrequestInterface.go
+++ b/authnrequestInterface.go
@@ -40,7 +40,6 @@ type AuthnRequest struct {
 	Issuer                         Issuer                `xml:"Issuer"`
 	NameIDPolicy                   NameIDPolicy          `xml:"NameIDPolicy"`
 	RequestedAuthnContext          RequestedAuthnContext `xml:"RequestedAuthnContext"`
-	AuthnContextClassRef           AuthnContextClassRef  `xml:"AuthnContextClassRef"`
 }
 
 type AuthnSignedRequest struct {
@@ -74,9 +73,10 @@ type NameIDPolicy struct {
 }
 
 type RequestedAuthnContext struct {
-	XMLName    xml.Name
-	SAMLP      string `xml:"xmlns:samlp,attr"`
-	Comparison string `xml:"Comparison,attr"`
+	XMLName              xml.Name
+	SAMLP                string               `xml:"xmlns:samlp,attr"`
+	Comparison           string               `xml:"Comparison,attr"`
+	AuthnContextClassRef AuthnContextClassRef `xml:"AuthnContextClassRef"`
 }
 
 type AuthnContextClassRef struct {

--- a/authnrequestInterface.go
+++ b/authnrequestInterface.go
@@ -33,10 +33,10 @@ type AuthnRequest struct {
 	ID                             string                `xml:"ID,attr"`
 	Version                        string                `xml:"Version,attr"`
 	ProtocolBinding                string                `xml:"ProtocolBinding,attr"`
-	AssertionConsumerServiceURL    string                `xml:"AssertionConsumerServiceURL,attr"`
+	AssertionConsumerServiceURL    string                `xml:"AssertionConsumerServiceURL,attr,omitempty"`
 	IssueInstant                   string                `xml:"IssueInstant,attr"`
-	AssertionConsumerServiceIndex  int                   `xml:"AssertionConsumerServiceIndex,attr"`
 	AttributeConsumingServiceIndex int                   `xml:"AttributeConsumingServiceIndex,attr"`
+	AssertionConsumerServiceIndex  int                   `xml:"AssertionConsumerServiceIndex,attr,omitempty"`
 	Issuer                         Issuer                `xml:"Issuer"`
 	NameIDPolicy                   NameIDPolicy          `xml:"NameIDPolicy"`
 	RequestedAuthnContext          RequestedAuthnContext `xml:"RequestedAuthnContext"`


### PR DESCRIPTION
Fix the following bugs detected during Shibboleth interoperation testing.

These fixes let gosaml work against http://www.testshib.org/, and were also tested against our internal Shibboleth server.
## Add omitempty to AssertionConsumerServiceIndex

Per (1), lines 2065-2067, AssertionConsumerServiceURL is mutually
exclusive with ACSIndex.  Since gosaml doesn't currently map ACSIndex,
just set it as omitempty so it'll not appear in the values.
## Move AuthnContextClassRef under RequestedAuthnCtx

Per (1), AuthnContextClassRef is a child of RequestedAuthnContext,
not AuthnRequest.
## Ensure auth request timestamp is UTC

per (1), line 312.
## Parameterize Url from Issuer

When building a request, pull the issuer URL rather than using an example.
### Appendix

1) Assertions and Protocols for the OASIS Security Assertion Markup
Language (SAML) V2.0,
http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf
