### PR TITLE
GetUrl - DEFLATE support, embed AuthnRequest in AuthnSignedRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ For instance, New Relic allows you to configure a saml provider (https://newreli
 
 Ping Identity has a nice video for SAML here: https://www.pingidentity.com/resource-center/Introduction-to-SAML-Video.cfm
 
+Shibboleth provides a test SAML IdP and SP endpoint at https://www.testshib.org/
+
 Installation
 ------------
 

--- a/authnrequest.go
+++ b/authnrequest.go
@@ -51,7 +51,7 @@ func NewAuthorizationRequest(appSettings AppSettings, accountSettings AccountSet
 // TODO: parameterize more parts of the request
 func (ar AuthorizationRequest) GetRequest(binding int) (string, error) {
 	bindings := map[int]string{
-		BindingPOST:     "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Post",
+		BindingPOST:     "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
 		BindingRedirect: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
 	}
 
@@ -275,13 +275,13 @@ func (ar AuthorizationRequest) GetSignedRequest(base64Encode bool, publicCert st
 
 // String reqString = accSettings.getIdp_sso_target_url()+"?SAMLRequest=" +
 // AuthRequest.getRidOfCRLF(URLEncoder.encode(authReq.getRequest(AuthRequest.base64),"UTF-8"));
-func (ar AuthorizationRequest) GetRequestUrl() (string, error) {
+func (ar AuthorizationRequest) GetRequestUrl(binding int) (string, error) {
 	u, err := url.Parse(ar.AccountSettings.IDP_SSO_Target_URL)
 	if err != nil {
 		return "", err
 	}
 
-	request, err := ar.GetRequest(BindingRedirect)
+	request, err := ar.GetRequest(binding)
 	if err != nil {
 		return "", err
 	}

--- a/authnrequestInterface.go
+++ b/authnrequestInterface.go
@@ -43,22 +43,10 @@ type AuthnRequest struct {
 }
 
 type AuthnSignedRequest struct {
-	XMLName                        xml.Name
-	SAMLP                          string                `xml:"xmlns:samlp,attr"`
-	SAML                           string                `xml:"xmlns:saml,attr"`
-	SAMLSIG                        string                `xml:"xmlns:samlsig,attr"`
-	ID                             string                `xml:"ID,attr"`
-	Version                        string                `xml:"Version,attr"`
-	ProtocolBinding                string                `xml:"ProtocolBinding,attr"`
-	AssertionConsumerServiceURL    string                `xml:"AssertionConsumerServiceURL,attr"`
-	IssueInstant                   string                `xml:"IssueInstant,attr"`
-	AssertionConsumerServiceIndex  int                   `xml:"AssertionConsumerServiceIndex,attr"`
-	AttributeConsumingServiceIndex int                   `xml:"AttributeConsumingServiceIndex,attr"`
-	Issuer                         Issuer                `xml:"Issuer"`
-	NameIDPolicy                   NameIDPolicy          `xml:"NameIDPolicy"`
-	RequestedAuthnContext          RequestedAuthnContext `xml:"RequestedAuthnContext"`
-	AuthnContextClassRef           AuthnContextClassRef  `xml:"AuthnContextClassRef"`
-	Signature                      Signature             `xml:"Signature"`
+	AuthnRequest
+	AuthnContextClassRef AuthnContextClassRef `xml:"AuthnContextClassRef"`
+	Signature            Signature            `xml:"Signature"`
+	SAMLSIG              string               `xml:"xmlns:samlsig,attr"`
 }
 
 type Issuer struct {

--- a/authnrequestInterface.go
+++ b/authnrequestInterface.go
@@ -35,7 +35,7 @@ type AuthnRequest struct {
 	ProtocolBinding                string                `xml:"ProtocolBinding,attr"`
 	AssertionConsumerServiceURL    string                `xml:"AssertionConsumerServiceURL,attr,omitempty"`
 	IssueInstant                   string                `xml:"IssueInstant,attr"`
-	AttributeConsumingServiceIndex int                   `xml:"AttributeConsumingServiceIndex,attr"`
+	AttributeConsumingServiceIndex int                   `xml:"AttributeConsumingServiceIndex,attr,omitemtpy"`
 	AssertionConsumerServiceIndex  int                   `xml:"AssertionConsumerServiceIndex,attr,omitempty"`
 	Issuer                         Issuer                `xml:"Issuer"`
 	NameIDPolicy                   NameIDPolicy          `xml:"NameIDPolicy"`


### PR DESCRIPTION
Here's a new round of changes that make this work more nicely with Shibboleth servers.  Highlights:
- All methods now take a binding method that allows the binding type to be changed.  I've tested this against HTTP-POST and HTTP-Redirect so far.
- GetRequestUrl() now deflates the data before base64 & URLEncode.  This is needed per the spec.
- I've embedded an AuthnRequest inside AuthnSignedRequest, which simplified things quite a bit.

You may not want to merge these - I've changed the signatures on some of those functions.  I'm not sure if I'm happy with that or not... I might poke at this a bit more to see if I can keep the API from changing.
